### PR TITLE
Added configurable extension types

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -176,6 +176,7 @@
    END OF TERMS AND CONDITIONS
 
    Copyright 2015 Hendrik Beskow
+   Copyright 2016 Christopher Aue
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
-mruby-simplemsgpack_ext
-=======================
+[![Build Status](https://travis-ci.org/Asmod4n/mruby-simplemsgpack.svg?branch=master)](https://travis-ci.org/Asmod4n/mruby-simplemsgpack)
+
+mruby-simplemsgpack
+===================
 
 Example
 -------
@@ -12,10 +14,6 @@ MessagePack.unpack(packed_hash) do |result|
 end
 ```
 
-By default, MessagePack packs symbols as strings and does not convert them
-back when unpacking them. Symbols can be preserved by registering an extension
-type for them.
-
 Packing an object is also possible using `MessagePack#pack`
 ```ruby
 MessagePack.pack(:an_object)
@@ -24,29 +22,39 @@ MessagePack.pack(:an_object)
 Extension Types
 ---------------
 
-To customize how objects are packed, define an extension type:
+To customize how objects are packed, define an [extension type](https://github.com/msgpack/msgpack/blob/master/spec.md#types-extension-type).
+
+By default, MessagePack packs symbols as strings and does not convert them
+back when unpacking them. Symbols can be preserved by registering an extension
+type for them:
 
 ```ruby
-MessagePack.register_pack_type(0, Symbol) { |symbol| symbol.to_s }
-MessagePack.register_unpack_type(0) { |data| data.to_sym }
+sym_ext_type = 0
+MessagePack.register_pack_type(sym_ext_type, Symbol) { |symbol| symbol.to_s }
+MessagePack.register_unpack_type(sym_ext_type) { |data| data.to_sym }
 
 MessagePack.unpack(:symbol.to_msgpack) # => :symbol
 ```
 
+Other object like classes can also be preserved:
+
+```ruby
+cls_ext_type = 1
+MessagePack.register_pack_type(cls_ext_type, Class) { |cls| cls.to_s }
+MessagePack.register_unpack_type(cls_ext_type) { |data| data.constantize }
+MessagePack.unpack(Object.to_msgpack) # => Object
+````
+
 For nil, true, false, Fixnum, Float, String, Array and Hash a registered
-ext type is ignored. They are always packed according to the MessagePack
-specification.
+ext type is ignored. They are always packed according to the [MessagePack
+specification](https://github.com/msgpack/msgpack/blob/master/spec.md).
 
 Acknowledgements
 ----------------
-This is using code from
+This is using code from https://github.com/msgpack/msgpack-c
 
-- https://github.com/msgpack/msgpack-c
-    Copyright (C) 2008-2015 FURUHASHI Sadayuki
-    Distributed under the Boost Software License, Version 1.0.
-    http://www.boost.org/LICENSE_1_0.txt
+Copyright (C) 2008-2015 FURUHASHI Sadayuki
 
-- https://github.com/Asmod4n/mruby-simplemsgpack
-    Copyright 2015 Hendrik Beskow
-    Distributed under the Apache License, Version 2.0
-    http://www.apache.org/licenses/LICENSE-2.0
+   Distributed under the Boost Software License, Version 1.0.
+   (See accompanying file LICENSE_1_0.txt or copy at
+   http://www.boost.org/LICENSE_1_0.txt)

--- a/README.md
+++ b/README.md
@@ -16,8 +16,15 @@ By default, MessagePack packs symbols as strings and does not convert them
 back when unpacking them. Symbols can be preserved by registering an extension
 type for them.
 
+Packing an object is also possible using `MessagePack#pack`
+```ruby
+MessagePack.pack(:an_object)
+````
+
 Extension Types
 ---------------
+
+To customize how objects are packed, define an extension type:
 
 ```ruby
 MessagePack.register_pack_type(0, Symbol) { |symbol| symbol.to_s }

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
-[![Build Status](https://travis-ci.org/Asmod4n/mruby-simplemsgpack.svg?branch=master)](https://travis-ci.org/Asmod4n/mruby-simplemsgpack)
-# mruby-simplemsgpack
+mruby-simplemsgpack_ext
+=======================
 
 Example
-=======
+-------
 
 ```ruby
 packed_hash = {foo: "bar", baz: [1, {ret: "val"}]}.to_msgpack + "bye".to_msgpack
@@ -12,23 +12,34 @@ MessagePack.unpack(packed_hash) do |result|
 end
 ```
 
-Ruby Symbols
-------------
+By default, MessagePack packs symbols as strings and does not convert them
+back when unpacking them. Symbols can be preserved by registering an extension
+type for them.
 
-Normally MessagePack knows nothing about Ruby Symbols, but since version 1 the Protocol is extensible.
-The usal catch here is that Ruby doesn't Garbage Collect Symbols and would then be able to exhause the Resources of the System when a Attacker would generate a unbounded Number of them.
-But mruby has a special function which only returns Symbols which are already created and nil otherwise.
-If you forcefully have to create symbols, pass another parameter to MessagePack.unpack, like this.
+Extension Types
+---------------
+
 ```ruby
-MessagePack.unpack(packed_hash, true)
+MessagePack.register_pack_type(0, Symbol) { |symbol| symbol.to_s }
+MessagePack.register_unpack_type(0) { |data| data.to_sym }
+
+MessagePack.unpack(:symbol.to_msgpack) # => :symbol
 ```
+
+For nil, true, false, Fixnum, Float, String, Array and Hash a registered
+ext type is ignored. They are always packed according to the MessagePack
+specification.
 
 Acknowledgements
 ----------------
-This is using code from https://github.com/msgpack/msgpack-c
+This is using code from
 
-Copyright (C) 2008-2015 FURUHASHI Sadayuki
+- https://github.com/msgpack/msgpack-c
+    Copyright (C) 2008-2015 FURUHASHI Sadayuki
+    Distributed under the Boost Software License, Version 1.0.
+    http://www.boost.org/LICENSE_1_0.txt
 
-   Distributed under the Boost Software License, Version 1.0.
-   (See accompanying file LICENSE_1_0.txt or copy at
-   http://www.boost.org/LICENSE_1_0.txt)
+- https://github.com/Asmod4n/mruby-simplemsgpack
+    Copyright 2015 Hendrik Beskow
+    Distributed under the Apache License, Version 2.0
+    http://www.apache.org/licenses/LICENSE-2.0

--- a/mrbgem.rake
+++ b/mrbgem.rake
@@ -1,8 +1,10 @@
-MRuby::Gem::Specification.new('mruby-simplemsgpack') do |spec|
+MRuby::Gem::Specification.new('mruby-simplemsgpack_ext') do |spec|
   spec.license = 'Apache-2'
-  spec.author  = 'Hendrik Beskow'
-  spec.summary = 'mruby bindings for msgpack'
+  spec.author  = 'Hendrik Beskow, Christopher Aue'
+  spec.summary = 'msgpack for mruby including extension types'
+  spec.homepage = "https://github.com/christopheraue/mruby-simplemsgpack_ext"
   spec.add_dependency 'mruby-errno'
   spec.add_dependency 'mruby-string-is-utf8'
   spec.add_conflict 'mruby-msgpack'
+  spec.add_conflict 'mruby-simplemsgpack'
 end

--- a/mrbgem.rake
+++ b/mrbgem.rake
@@ -1,10 +1,9 @@
-MRuby::Gem::Specification.new('mruby-simplemsgpack_ext') do |spec|
+MRuby::Gem::Specification.new('mruby-simplemsgpack') do |spec|
   spec.license = 'Apache-2'
   spec.author  = 'Hendrik Beskow, Christopher Aue'
   spec.summary = 'msgpack for mruby including extension types'
-  spec.homepage = "https://github.com/christopheraue/mruby-simplemsgpack_ext"
+  spec.homepage = 'https://github.com/Asmod4n/mruby-simplemsgpack'
   spec.add_dependency 'mruby-errno'
   spec.add_dependency 'mruby-string-is-utf8'
   spec.add_conflict 'mruby-msgpack'
-  spec.add_conflict 'mruby-simplemsgpack'
 end

--- a/src/mrb_msgpack.c
+++ b/src/mrb_msgpack.c
@@ -119,7 +119,7 @@ mrb_msgpack_pack_ext_value(mrb_state* mrb, mrb_value self, msgpack_packer* pk)
         mrb_raise(mrb, E_MSGPACK_ERROR, "no string returned by ext type packer");
     }
 
-    body = mrb_string_value_ptr(mrb, packed);
+    body = mrb_str_to_cstr(mrb, packed);
     len = strlen(body);
 
     msgpack_pack_ext(pk, len, mrb_fixnum(type));

--- a/src/mrb_msgpack.c
+++ b/src/mrb_msgpack.c
@@ -563,7 +563,7 @@ mrb_msgpack_register_unpack_type(mrb_state* mrb, mrb_value self)
 }
 
 void
-mrb_mruby_simplemsgpack_ext_gem_init(mrb_state* mrb)
+mrb_mruby_simplemsgpack_gem_init(mrb_state* mrb)
 {
     struct RClass* msgpack_mod;
 
@@ -594,4 +594,4 @@ mrb_mruby_simplemsgpack_ext_gem_init(mrb_state* mrb)
     mrb_define_module_function(mrb, msgpack_mod, "register_unpack_type", mrb_msgpack_register_unpack_type, (MRB_ARGS_REQ(1)|MRB_ARGS_BLOCK()));
 }
 
-void mrb_mruby_simplemsgpack_ext_gem_final(mrb_state* mrb) { }
+void mrb_mruby_simplemsgpack_gem_final(mrb_state* mrb) { }

--- a/src/mrb_msgpack.c
+++ b/src/mrb_msgpack.c
@@ -517,7 +517,7 @@ mrb_msgpack_register_unpack_type(mrb_state* mrb, mrb_value self)
 }
 
 void
-mrb_mruby_simplemsgpack_gem_init(mrb_state* mrb)
+mrb_mruby_simplemsgpack_ext_gem_init(mrb_state* mrb)
 {
     struct RClass* msgpack_mod;
 
@@ -541,4 +541,4 @@ mrb_mruby_simplemsgpack_gem_init(mrb_state* mrb)
     mrb_define_module_function(mrb, msgpack_mod, "register_unpack_type", mrb_msgpack_register_unpack_type, (MRB_ARGS_REQ(1)|MRB_ARGS_BLOCK()));
 }
 
-void mrb_mruby_simplemsgpack_gem_final(mrb_state* mrb) { }
+void mrb_mruby_simplemsgpack_ext_gem_final(mrb_state* mrb) { }

--- a/src/mrb_msgpack.c
+++ b/src/mrb_msgpack.c
@@ -16,12 +16,8 @@ typedef struct {
     mrb_value buffer;
 } mrb_msgpack_data;
 
-typedef struct mrb_msgpack_ext_registry {
-    mrb_value packers;
-    mrb_value unpackers;
-} mrb_msgpack_ext_registry;
-
-static mrb_msgpack_ext_registry ext_registry;
+static mrb_value ext_packers;
+static mrb_value ext_unpackers;
 
 #if (__GNUC__ >= 3) || (__INTEL_COMPILER >= 800) || defined(__clang__)
 #define likely(x) __builtin_expect(!!(x), 1)
@@ -81,21 +77,21 @@ MRB_INLINE mrb_value
 mrb_msgpack_get_ext_config(mrb_state* mrb, mrb_value obj)
 {
     mrb_value obj_class = mrb_obj_value(mrb_obj_class(mrb, obj));
-    mrb_value ext_config = mrb_hash_get(mrb, ext_registry.packers, obj_class);
+    mrb_value ext_config = mrb_hash_get(mrb, ext_packers, obj_class);
 
     if (!mrb_nil_p(ext_config)) {
         return ext_config;
     }
 
-    mrb_value ext_type_classes = mrb_funcall(mrb, ext_registry.packers, "keys", 0);
+    mrb_value ext_type_classes = mrb_funcall(mrb, ext_packers, "keys", 0);
     mrb_int classes_count = RARRAY_LEN(ext_type_classes);
 
     for (mrb_int i = 0; i < classes_count; i += 1) {
         mrb_value ext_type_class = mrb_ary_ref(mrb, ext_type_classes, i);
 
         if (mrb_obj_is_kind_of(mrb, obj, mrb_class_ptr(ext_type_class))) {
-            ext_config = mrb_hash_get(mrb, ext_registry.packers, ext_type_class);
-            mrb_hash_set(mrb, ext_registry.packers, obj_class, ext_config);
+            ext_config = mrb_hash_get(mrb, ext_packers, ext_type_class);
+            mrb_hash_set(mrb, ext_packers, obj_class, ext_config);
             return ext_config;
         }
     }
@@ -396,7 +392,7 @@ mrb_unpack_msgpack_obj(mrb_state* mrb, msgpack_object obj)
             return mrb_str_new(mrb, obj.via.bin.ptr, obj.via.bin.size);
             break;
         case MSGPACK_OBJECT_EXT: {
-            mrb_value unpacker = mrb_hash_get(mrb, ext_registry.unpackers, mrb_fixnum_value(obj.via.ext.type));
+            mrb_value unpacker = mrb_hash_get(mrb, ext_unpackers, mrb_fixnum_value(obj.via.ext.type));
             mrb_value data = mrb_str_new_static(mrb, obj.via.ext.ptr, obj.via.ext.size);
 
             return mrb_yield(mrb, unpacker, data);
@@ -522,7 +518,7 @@ mrb_msgpack_register_pack_type(mrb_state* mrb, mrb_value self)
     ext_config = mrb_hash_new(mrb);
     mrb_hash_set(mrb, ext_config, mrb_symbol_value(mrb_intern_lit(mrb, "type")), mrb_fixnum_value(type));
     mrb_hash_set(mrb, ext_config, mrb_symbol_value(mrb_intern_lit(mrb, "packer")), block);
-    mrb_hash_set(mrb, ext_registry.packers, mrb_class, ext_config);
+    mrb_hash_set(mrb, ext_packers, mrb_class, ext_config);
 
     return mrb_nil_value();
 }
@@ -543,7 +539,7 @@ mrb_msgpack_register_unpack_type(mrb_state* mrb, mrb_value self)
         mrb_raise(mrb, E_MSGPACK_ERROR, "no block");
     }
 
-    mrb_hash_set(mrb, ext_registry.unpackers, mrb_fixnum_value(type), block);
+    mrb_hash_set(mrb, ext_unpackers, mrb_fixnum_value(type), block);
 
     return mrb_nil_value();
 }
@@ -553,8 +549,8 @@ mrb_mruby_simplemsgpack_ext_gem_init(mrb_state* mrb)
 {
     struct RClass* msgpack_mod;
 
-    ext_registry.packers = mrb_hash_new(mrb);
-    ext_registry.unpackers = mrb_hash_new(mrb);
+    ext_packers = mrb_hash_new(mrb);
+    ext_unpackers = mrb_hash_new(mrb);
 
     mrb_define_method(mrb, mrb->object_class, "to_msgpack", mrb_msgpack_pack_object, MRB_ARGS_NONE());
     mrb_define_method(mrb, mrb->string_class, "to_msgpack", mrb_msgpack_pack_string, MRB_ARGS_NONE());
@@ -568,6 +564,12 @@ mrb_mruby_simplemsgpack_ext_gem_init(mrb_state* mrb)
 
     msgpack_mod = mrb_define_module(mrb, "MessagePack");
     mrb_define_class_under(mrb, msgpack_mod, "Error", E_RUNTIME_ERROR);
+
+    // attach hashes with packers and unpackers to MessagePack module as
+    // instance variables to prevent garbage collection.
+    mrb_iv_set(mrb, mrb_obj_value(msgpack_mod), mrb_intern_lit(mrb, "ext_packers"), ext_packers);
+    mrb_iv_set(mrb, mrb_obj_value(msgpack_mod), mrb_intern_lit(mrb, "ext_unpackers"), ext_unpackers);
+
     mrb_define_module_function(mrb, msgpack_mod, "unpack", mrb_msgpack_unpack, (MRB_ARGS_ARG(1, 0)|MRB_ARGS_BLOCK()));
     mrb_define_module_function(mrb, msgpack_mod, "register_pack_type", mrb_msgpack_register_pack_type, (MRB_ARGS_REQ(2)|MRB_ARGS_BLOCK()));
     mrb_define_module_function(mrb, msgpack_mod, "register_unpack_type", mrb_msgpack_register_unpack_type, (MRB_ARGS_REQ(1)|MRB_ARGS_BLOCK()));

--- a/src/mrb_msgpack.c
+++ b/src/mrb_msgpack.c
@@ -88,7 +88,7 @@ mrb_msgpack_get_ext_config(mrb_state* mrb, mrb_value obj)
     }
 
     mrb_value ext_type_classes = mrb_funcall(mrb, ext_registry.packers, "keys", 0);
-    mrb_int classes_count = mrb_ary_ptr(ext_type_classes)->len;
+    mrb_int classes_count = RARRAY_LEN(ext_type_classes);
 
     for (mrb_int i = 0; i < classes_count; i += 1) {
         mrb_value ext_type_class = mrb_ary_ref(mrb, ext_type_classes, i);
@@ -495,7 +495,7 @@ mrb_msgpack_unpack(mrb_state* mrb, mrb_value self)
         mrb_sys_fail(mrb, "msgpack_unpack_next");
     }
     if (ret == MSGPACK_UNPACK_PARSE_ERROR) {
-        mrb_raise(mrb, E_MSGPACK_ERROR, "Invalid data recieved");
+        mrb_raise(mrb, E_MSGPACK_ERROR, "Invalid data received");
     }
 
     return unpack_return;

--- a/src/mrb_msgpack.c
+++ b/src/mrb_msgpack.c
@@ -440,6 +440,24 @@ mrb_unpack_msgpack_obj_map(mrb_state* mrb, msgpack_object obj)
 }
 
 static mrb_value
+mrb_msgpack_pack(mrb_state* mrb, mrb_value self)
+{
+    mrb_value object;
+
+    mrb_get_args(mrb, "o", &object);
+
+    msgpack_packer pk;
+    mrb_msgpack_data data;
+    data.mrb = mrb;
+    data.buffer = mrb_str_new(mrb, NULL, 0);
+    msgpack_packer_init(&pk, &data, mrb_msgpack_data_write);
+
+    mrb_msgpack_pack_value(mrb, object, &pk);
+
+    return data.buffer;
+}
+
+static mrb_value
 mrb_msgpack_unpack(mrb_state* mrb, mrb_value self)
 {
     mrb_value data, block = mrb_nil_value();
@@ -570,6 +588,7 @@ mrb_mruby_simplemsgpack_ext_gem_init(mrb_state* mrb)
     mrb_iv_set(mrb, mrb_obj_value(msgpack_mod), mrb_intern_lit(mrb, "ext_packers"), ext_packers);
     mrb_iv_set(mrb, mrb_obj_value(msgpack_mod), mrb_intern_lit(mrb, "ext_unpackers"), ext_unpackers);
 
+    mrb_define_module_function(mrb, msgpack_mod, "pack", mrb_msgpack_pack, (MRB_ARGS_REQ(1)));
     mrb_define_module_function(mrb, msgpack_mod, "unpack", mrb_msgpack_unpack, (MRB_ARGS_ARG(1, 0)|MRB_ARGS_BLOCK()));
     mrb_define_module_function(mrb, msgpack_mod, "register_pack_type", mrb_msgpack_register_pack_type, (MRB_ARGS_REQ(2)|MRB_ARGS_BLOCK()));
     mrb_define_module_function(mrb, msgpack_mod, "register_unpack_type", mrb_msgpack_register_unpack_type, (MRB_ARGS_REQ(1)|MRB_ARGS_BLOCK()));

--- a/src/mrb_msgpack.c
+++ b/src/mrb_msgpack.c
@@ -393,7 +393,7 @@ mrb_unpack_msgpack_obj(mrb_state* mrb, msgpack_object obj)
             break;
         case MSGPACK_OBJECT_EXT: {
             mrb_value unpacker = mrb_hash_get(mrb, ext_unpackers, mrb_fixnum_value(obj.via.ext.type));
-            mrb_value data = mrb_str_new_static(mrb, obj.via.ext.ptr, obj.via.ext.size);
+            mrb_value data = mrb_str_new(mrb, obj.via.ext.ptr, obj.via.ext.size);
 
             return mrb_yield(mrb, unpacker, data);
         } break;

--- a/src/mrb_msgpack.c
+++ b/src/mrb_msgpack.c
@@ -59,15 +59,6 @@ mrb_msgpack_pack_float_value(mrb_value self, msgpack_packer* pk)
 }
 
 MRB_INLINE void
-mrb_msgpack_pack_symbol_value(mrb_state* mrb, mrb_value self, msgpack_packer* pk)
-{
-    mrb_int len;
-    const char* name = mrb_sym2name_len(mrb, mrb_symbol(self), &len);
-    msgpack_pack_ext(pk, len, 1);
-    msgpack_pack_ext_body(pk, name, len);
-}
-
-MRB_INLINE void
 mrb_msgpack_pack_string_value(mrb_value self, msgpack_packer* pk)
 {
     if (mrb_str_is_utf8(self)) {
@@ -77,16 +68,6 @@ mrb_msgpack_pack_string_value(mrb_value self, msgpack_packer* pk)
         msgpack_pack_bin(pk, RSTRING_LEN(self));
         msgpack_pack_bin_body(pk, RSTRING_PTR(self), RSTRING_LEN(self));
     }
-}
-
-MRB_INLINE void
-mrb_msgpack_pack_class_value(mrb_state* mrb, mrb_value self, msgpack_packer* pk)
-{
-    struct RClass* mrb_class = mrb_class_ptr(self);
-    const char* class_name = mrb_class_name(mrb, mrb_class);
-    size_t len = strlen(class_name);
-    msgpack_pack_ext(pk, len, 2);
-    msgpack_pack_ext_body(pk, class_name, len);
 }
 
 MRB_INLINE void
@@ -112,16 +93,8 @@ mrb_msgpack_pack_value(mrb_state* mrb, mrb_value self, msgpack_packer* pk)
         case MRB_TT_FIXNUM:
             mrb_msgpack_pack_fixnum_value(self, pk);
             break;
-        case MRB_TT_SYMBOL:
-            mrb_msgpack_pack_symbol_value(mrb, self, pk);
-            break;
         case MRB_TT_FLOAT:
             mrb_msgpack_pack_float_value(self, pk);
-            break;
-        case MRB_TT_CLASS:
-        case MRB_TT_MODULE:
-        case MRB_TT_SCLASS:
-            mrb_msgpack_pack_class_value(mrb, self, pk);
             break;
         case MRB_TT_ARRAY:
             mrb_msgpack_pack_array_value(mrb, self, pk);
@@ -150,13 +123,8 @@ mrb_msgpack_pack_value(mrb_state* mrb, mrb_value self, msgpack_packer* pk)
                         if (mrb_string_p(try_convert)) {
                             mrb_msgpack_pack_string_value(try_convert, pk);
                         } else {
-                            try_convert = mrb_check_convert_type(mrb, self, MRB_TT_SYMBOL, "Symbol", "to_sym");
-                            if (mrb_symbol_p(try_convert)) {
-                                mrb_msgpack_pack_symbol_value(mrb, try_convert, pk);
-                            } else {
-                                try_convert = mrb_convert_type(mrb, self, MRB_TT_STRING, "String", "to_s");
-                                mrb_msgpack_pack_string_value(try_convert, pk);
-                            }
+                            try_convert = mrb_convert_type(mrb, self, MRB_TT_STRING, "String", "to_s");
+                            mrb_msgpack_pack_string_value(try_convert, pk);
                         }
                     }
                 }
@@ -314,42 +282,14 @@ mrb_msgpack_pack_nil(mrb_state* mrb, mrb_value self)
     return data.buffer;
 }
 
-static mrb_value
-mrb_msgpack_pack_symbol(mrb_state* mrb, mrb_value self)
-{
-    msgpack_packer pk;
-    mrb_msgpack_data data;
-    data.mrb = mrb;
-    data.buffer = mrb_str_new(mrb, NULL, 0);
-    msgpack_packer_init(&pk, &data, mrb_msgpack_data_write);
-
-    mrb_msgpack_pack_symbol_value(mrb, self, &pk);
-
-    return data.buffer;
-}
-
-static mrb_value
-mrb_msgpack_pack_class(mrb_state* mrb, mrb_value self)
-{
-    msgpack_packer pk;
-    mrb_msgpack_data data;
-    data.mrb = mrb;
-    data.buffer = mrb_str_new(mrb, NULL, 0);
-    msgpack_packer_init(&pk, &data, mrb_msgpack_data_write);
-
-    mrb_msgpack_pack_class_value(mrb, self, &pk);
-
-    return data.buffer;
-}
+MRB_INLINE mrb_value
+mrb_unpack_msgpack_obj_array(mrb_state* mrb, msgpack_object obj);
 
 MRB_INLINE mrb_value
-mrb_unpack_msgpack_obj_array(mrb_state* mrb, msgpack_object obj, mrb_bool force_symbols);
+mrb_unpack_msgpack_obj_map(mrb_state* mrb, msgpack_object obj);
 
 MRB_INLINE mrb_value
-mrb_unpack_msgpack_obj_map(mrb_state* mrb, msgpack_object obj, mrb_bool force_symbols);
-
-MRB_INLINE mrb_value
-mrb_unpack_msgpack_obj(mrb_state* mrb, msgpack_object obj, mrb_bool force_symbols)
+mrb_unpack_msgpack_obj(mrb_state* mrb, msgpack_object obj)
 {
     switch (obj.type) {
         case MSGPACK_OBJECT_NIL:
@@ -383,46 +323,27 @@ mrb_unpack_msgpack_obj(mrb_state* mrb, msgpack_object obj, mrb_bool force_symbol
             return mrb_str_new(mrb, obj.via.str.ptr, obj.via.str.size);
             break;
         case MSGPACK_OBJECT_ARRAY:
-            return mrb_unpack_msgpack_obj_array(mrb, obj, force_symbols);
+            return mrb_unpack_msgpack_obj_array(mrb, obj);
             break;
         case MSGPACK_OBJECT_MAP:
-            return mrb_unpack_msgpack_obj_map(mrb, obj, force_symbols);
+            return mrb_unpack_msgpack_obj_map(mrb, obj);
             break;
         case MSGPACK_OBJECT_BIN:
             return mrb_str_new(mrb, obj.via.bin.ptr, obj.via.bin.size);
             break;
-        case MSGPACK_OBJECT_EXT: {
-            switch (obj.via.ext.type) {
-                case 1: {
-                    if (force_symbols) {
-                        return mrb_symbol_value(mrb_intern(mrb, obj.via.ext.ptr, obj.via.ext.size));
-                    } else {
-                        return mrb_check_intern(mrb, obj.via.ext.ptr, obj.via.ext.size);
-                    }
-                } break;
-                case 2: {
-                    mrb_value classname_obj = mrb_str_new_static(mrb, obj.via.ext.ptr, obj.via.ext.size);
-                    return mrb_funcall(mrb, classname_obj, "constantize", 0);
-                } break;
-                default: {
-                    mrb_warn(mrb, "Cannot unpack ext type %S, returning a raw string", mrb_fixnum_value(obj.via.ext.type));
-                    return mrb_str_new(mrb, obj.via.ext.ptr, obj.via.ext.size);
-                }
-            }
-        } break;
         default:
             mrb_raisef(mrb, E_MSGPACK_ERROR, "Cannot unpack type %S", mrb_fixnum_value(obj.type));
     }
 }
 
 MRB_INLINE mrb_value
-mrb_unpack_msgpack_obj_array(mrb_state* mrb, msgpack_object obj, mrb_bool force_symbols)
+mrb_unpack_msgpack_obj_array(mrb_state* mrb, msgpack_object obj)
 {
     if (obj.via.array.size != 0) {
         mrb_value unpacked_array = mrb_ary_new_capa(mrb, obj.via.array.size);
         int ai = mrb_gc_arena_save(mrb);
         for (size_t array_pos = 0; array_pos < obj.via.array.size; array_pos++) {
-            mrb_value unpacked_obj = mrb_unpack_msgpack_obj(mrb, obj.via.array.ptr[array_pos], force_symbols);
+            mrb_value unpacked_obj = mrb_unpack_msgpack_obj(mrb, obj.via.array.ptr[array_pos]);
             mrb_ary_push(mrb, unpacked_array, unpacked_obj);
             mrb_gc_arena_restore(mrb, ai);
         }
@@ -434,14 +355,14 @@ mrb_unpack_msgpack_obj_array(mrb_state* mrb, msgpack_object obj, mrb_bool force_
 }
 
 MRB_INLINE mrb_value
-mrb_unpack_msgpack_obj_map(mrb_state* mrb, msgpack_object obj, mrb_bool force_symbols)
+mrb_unpack_msgpack_obj_map(mrb_state* mrb, msgpack_object obj)
 {
     if (obj.via.map.size != 0) {
         mrb_value unpacked_hash = mrb_hash_new_capa(mrb, obj.via.map.size);
         int ai = mrb_gc_arena_save(mrb);
         for (size_t map_pos = 0; map_pos < obj.via.map.size; map_pos++) {
-            mrb_value unpacked_key = mrb_unpack_msgpack_obj(mrb, obj.via.map.ptr[map_pos].key, force_symbols);
-            mrb_value unpacked_value = mrb_unpack_msgpack_obj(mrb, obj.via.map.ptr[map_pos].val, force_symbols);
+            mrb_value unpacked_key = mrb_unpack_msgpack_obj(mrb, obj.via.map.ptr[map_pos].key);
+            mrb_value unpacked_value = mrb_unpack_msgpack_obj(mrb, obj.via.map.ptr[map_pos].val);
             mrb_hash_set(mrb, unpacked_hash, unpacked_key, unpacked_value);
             mrb_gc_arena_restore(mrb, ai);
         }
@@ -456,9 +377,8 @@ static mrb_value
 mrb_msgpack_unpack(mrb_state* mrb, mrb_value self)
 {
     mrb_value data, block = mrb_nil_value();
-    mrb_bool force_symbols = FALSE;
 
-    mrb_get_args(mrb, "o|b&", &data, &force_symbols, &block);
+    mrb_get_args(mrb, "o&", &data, &block);
 
     data = mrb_str_to_str(mrb, data);
 
@@ -478,12 +398,12 @@ mrb_msgpack_unpack(mrb_state* mrb, mrb_value self)
         mrb->jmp = &c_jmp;
         if (mrb_nil_p(block)) {
             if (ret == MSGPACK_UNPACK_SUCCESS) {
-                unpack_return = mrb_unpack_msgpack_obj(mrb, result.data, force_symbols);
+                unpack_return = mrb_unpack_msgpack_obj(mrb, result.data);
             }
         } else {
             int ai = mrb_gc_arena_save(mrb);
             while (ret == MSGPACK_UNPACK_SUCCESS) {
-                mrb_value unpacked_obj = mrb_unpack_msgpack_obj(mrb, result.data, force_symbols);
+                mrb_value unpacked_obj = mrb_unpack_msgpack_obj(mrb, result.data);
                 mrb_yield(mrb, block, unpacked_obj);
                 mrb_gc_arena_restore(mrb, ai);
                 ret = msgpack_unpack_next(&result, RSTRING_PTR(data), RSTRING_LEN(data), &off);
@@ -525,13 +445,10 @@ mrb_mruby_simplemsgpack_gem_init(mrb_state* mrb)
     mrb_define_method(mrb, mrb->true_class, "to_msgpack", mrb_msgpack_pack_true, MRB_ARGS_NONE());
     mrb_define_method(mrb, mrb->false_class, "to_msgpack", mrb_msgpack_pack_false, MRB_ARGS_NONE());
     mrb_define_method(mrb, mrb->nil_class, "to_msgpack", mrb_msgpack_pack_nil, MRB_ARGS_NONE());
-    mrb_define_method(mrb, mrb->symbol_class, "to_msgpack", mrb_msgpack_pack_symbol, MRB_ARGS_NONE());
-    mrb_define_method(mrb, mrb->class_class, "to_msgpack", mrb_msgpack_pack_class, MRB_ARGS_NONE());
-    mrb_define_method(mrb, mrb->module_class, "to_msgpack", mrb_msgpack_pack_class, MRB_ARGS_NONE());
 
     msgpack_mod = mrb_define_module(mrb, "MessagePack");
     mrb_define_class_under(mrb, msgpack_mod, "Error", E_RUNTIME_ERROR);
-    mrb_define_module_function(mrb, msgpack_mod, "unpack", mrb_msgpack_unpack, (MRB_ARGS_ARG(1, 1)|MRB_ARGS_BLOCK()));
+    mrb_define_module_function(mrb, msgpack_mod, "unpack", mrb_msgpack_unpack, (MRB_ARGS_ARG(1, 0)|MRB_ARGS_BLOCK()));
 }
 
 void mrb_mruby_simplemsgpack_gem_final(mrb_state* mrb) { }

--- a/test/msgpack.rb
+++ b/test/msgpack.rb
@@ -1,17 +1,21 @@
 assert("NilClass#to_msgpack") do
   assert_equal(nil, MessagePack.unpack(nil.to_msgpack))
+  assert_equal(nil, MessagePack.unpack(MessagePack.pack(nil)))
 end
 
 assert("FalseClass#to_msgpack") do
   assert_equal(false, MessagePack.unpack(false.to_msgpack))
+  assert_equal(false, MessagePack.unpack(MessagePack.pack(false)))
 end
 
 assert("TrueClass#to_msgpack") do
   assert_equal(true, MessagePack.unpack(true.to_msgpack))
+  assert_equal(true, MessagePack.unpack(MessagePack.pack(true)))
 end
 
 assert("Integer#to_msgpack") do
   assert_equal(1, MessagePack.unpack(1.to_msgpack))
+  assert_equal(1, MessagePack.unpack(MessagePack.pack(1)))
   assert_equal(-1, MessagePack.unpack(-1.to_msgpack))
   assert_equal(-2**63, MessagePack.unpack((-2**63).to_msgpack))
   assert_equal(2**64-1, MessagePack.unpack((2**64-1).to_msgpack))
@@ -19,26 +23,31 @@ end
 
 assert("Float#to_msgpack") do
   assert_equal(1.2, MessagePack.unpack(1.2.to_msgpack))
+  assert_equal(1.2, MessagePack.unpack(MessagePack.pack(1.2)))
   assert_equal(1.7976931348623157e+308, MessagePack.unpack(1.7976931348623157e+308.to_msgpack))
   assert_equal(2.2250738585072014e-308, MessagePack.unpack(2.2250738585072014e-308.to_msgpack))
 end
 
 assert("String#to_msgpack") do
   assert_equal('string', MessagePack.unpack('string'.to_msgpack))
+  assert_equal('string', MessagePack.unpack(MessagePack.pack('string')))
 end
 
 assert("Symbol#to_msgpack") do
   assert_equal('symbol', MessagePack.unpack(:symbol.to_msgpack))
+  assert_equal('symbol', MessagePack.unpack(MessagePack.pack(:symbol)))
 end
 
 assert("Array#to_msgpack") do
   array = [nil, false, true, 1, -1, 1.2, "string", [], {}]
   assert_equal(array, MessagePack.unpack(array.to_msgpack))
+  assert_equal(array, MessagePack.unpack(MessagePack.pack(array)))
 end
 
 assert("Hash#to_msgpack") do
   hash = { nil => nil, false => false, true => true, 1 => 1, 1.2 => 1.2, "string" => "string", [] => [], {} => {} }
   assert_equal(hash, MessagePack.unpack(hash.to_msgpack))
+  assert_equal(hash, MessagePack.unpack(MessagePack.pack(hash)))
 end
 
 assert("Module#to_msgpack") do
@@ -84,6 +93,7 @@ assert("Symbol#to_msgpack with registered ext type") do
 
   hash = { key: 123, nested: [:array] }
   assert_equal(hash, MessagePack.unpack(hash.to_msgpack))
+  assert_equal(hash, MessagePack.unpack(MessagePack.pack(hash)))
 end
 
 assert("Class#to_msgpack with registered ext type") do

--- a/test/msgpack.rb
+++ b/test/msgpack.rb
@@ -1,5 +1,43 @@
-assert("Object#to_msgpack") do
-  obj = [1, -1, MessagePack, "hallo", nil, false, true, [1, -1, nil, false, true], hashie: {ary: [1, -1, nil, false, true], hashie: {ary: [1, -1, nil, false, true]}}]
-  assert_equal(obj, MessagePack.unpack(obj.to_msgpack))
+assert("NilClass#to_msgpack") do
+  assert_equal(nil, MessagePack.unpack(nil.to_msgpack))
+end
+
+assert("FalseClass#to_msgpack") do
+  assert_equal(false, MessagePack.unpack(false.to_msgpack))
+end
+
+assert("TrueClass#to_msgpack") do
+  assert_equal(true, MessagePack.unpack(true.to_msgpack))
+end
+
+assert("Integer#to_msgpack") do
+  assert_equal(1, MessagePack.unpack(1.to_msgpack))
+  assert_equal(-1, MessagePack.unpack(-1.to_msgpack))
+  assert_equal(-2**63, MessagePack.unpack((-2**63).to_msgpack))
+  assert_equal(2**64-1, MessagePack.unpack((2**64-1).to_msgpack))
+end
+
+assert("Float#to_msgpack") do
+  assert_equal(1.2, MessagePack.unpack(1.2.to_msgpack))
+  assert_equal(1.7976931348623157e+308, MessagePack.unpack(1.7976931348623157e+308.to_msgpack))
+  assert_equal(2.2250738585072014e-308, MessagePack.unpack(2.2250738585072014e-308.to_msgpack))
+end
+
+assert("String#to_msgpack") do
+  assert_equal('string', MessagePack.unpack('string'.to_msgpack))
+end
+
+assert("Symbol#to_msgpack") do
+  assert_equal('symbol', MessagePack.unpack(:symbol.to_msgpack))
+end
+
+assert("Array#to_msgpack") do
+  array = [nil, false, true, 1, -1, 1.2, "string", [], {}]
+  assert_equal(array, MessagePack.unpack(array.to_msgpack))
+end
+
+assert("Hash#to_msgpack") do
+  hash = { nil => nil, false => false, true => true, 1 => 1, 1.2 => 1.2, "string" => "string", [] => [], {} => {} }
+  assert_equal(hash, MessagePack.unpack(hash.to_msgpack))
 end
 


### PR DESCRIPTION
- Removed hard coded ext types for `Symbol`, `Module` and `Class`
- Added `MessagePack.register_pack_type(type, klass, &packer)`
- Added `MessagePack.register_unpack_type(type, &unpacker)`
- Added `MessagePack.pack(object)` to be able to pack BasicObjects having an ext type without the need to add `BasicObject#to_msgpack`
- Updated README