### PR TITLE
Let MessagePack.unpack(data, &block) return number of bytes unpacked

### DIFF
--- a/src/mrb_msgpack.c
+++ b/src/mrb_msgpack.c
@@ -487,6 +487,7 @@ mrb_msgpack_unpack(mrb_state* mrb, mrb_value self)
                 mrb_gc_arena_restore(mrb, ai);
                 ret = msgpack_unpack_next(&result, RSTRING_PTR(data), RSTRING_LEN(data), &off);
             }
+            unpack_return = mrb_fixnum_value(off);
         }
         mrb->jmp = prev_jmp;
     }


### PR DESCRIPTION
Reading from a stream very likely returns packed data with an incomplete object at the end. To unpack what's ready and continue to unpack the incomplete object once more data arrived one needs to know how much of the given data has been unpacked.

This PR changes the return value of `MessagePack.unpack(data)` if called with a block from `self` to the offset in `data` after the last complete unpack operation.